### PR TITLE
Keep `:root` selector in Firefox

### DIFF
--- a/src/apply-shim.js
+++ b/src/apply-shim.js
@@ -132,7 +132,7 @@ class ApplyShim {
     // :root was only used for variable assignment in property shim,
     // but generates invalid selectors with real properties.
     // replace with `:host > *`, which serves the same effect
-    if (rule.selector === ':root') {
+    if (typeof InstallTrigger === 'undefined' && rule.selector === ':root') {
       rule.selector = ':host > *';
     }
   }


### PR DESCRIPTION
In Firefox `:host > *` doesn't work, while `:root` does.
