### PR TITLE
Fix bower after split-shadycss merge

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "shadycss",
-  "main": "shadycss.min.js",
+  "main": "apply-shim.html",
   "authors": [
     "The Polymer Authors"
   ],
@@ -22,7 +22,7 @@
     "template": "webcomponents/template#master",
     "html-imports": "webcomponents/html-imports#master",
     "custom-elements": "webcomponents/custom-elements#master",
-    "shadydom": "webcomponents/shadydom#split-shadycss",
+    "shadydom": "webcomponents/shadydom#master",
     "webcomponents-platform": "webcomponents/webcomponents-platform#master"
   }
 }


### PR DESCRIPTION
Use webcomponents/shadydom#master as dependency,
#split-shadycss no longer exists
Set main to apply-shim.html
Fixes #54

And  hopefully lets https://github.com/webcomponents/shadycss/pull/48 checks pass.
