### PR TITLE
Prevent logging errors on IE11

### DIFF
--- a/src/scoping-shim.js
+++ b/src/scoping-shim.js
@@ -155,7 +155,7 @@ export default class ScopingShim {
   _ensureApplyShim() {
     if (this._applyShim) {
       return;
-    } else if (window.ShadyCSS.ApplyShim) {
+    } else if (window.ShadyCSS && window.ShadyCSS.ApplyShim) {
       this._applyShim = window.ShadyCSS.ApplyShim;
       this._applyShim['invalidCallback'] = ApplyShimUtils.invalidate;
     } else {


### PR DESCRIPTION
Ensure that the object exists before asking for a specific property