### PR TITLE
Add a clarification of the limitation of ShadyCSS for document level styling.

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,3 +351,9 @@ the polyfill.  This is mainly due to the fact that shimming them would require
 a fetch of the stylesheet text that is async cannot be easily coordinated with
 the upgrade timing of custom elements using them, making it impossible to avoid
 "flash of unstyled content" when running on polyfill.
+
+### Document level styling is not prevented
+
+ShadyCSS mimics the behavior of shadow dom, but it is not able to prevent document
+level styling to affect elements inside a shady dom. Global styles defined in
+`index.html` or any styles not processed by ShadyCSS will affect all elements on the page.

--- a/README.md
+++ b/README.md
@@ -352,8 +352,9 @@ a fetch of the stylesheet text that is async cannot be easily coordinated with
 the upgrade timing of custom elements using them, making it impossible to avoid
 "flash of unstyled content" when running on polyfill.
 
-### Document level styling is not prevented
+### (Dynamic) document level styling is not prevented
 
 ShadyCSS mimics the behavior of shadow dom, but it is not able to prevent document
 level styling to affect elements inside a shady dom. Global styles defined in
 `index.html` or any styles not processed by ShadyCSS will affect all elements on the page.
+This includes styles that are dynamically created and appended to the DOM.


### PR DESCRIPTION
Add a clarification of the limitation of ShadyCSS for document level styling.

Closes https://github.com/webcomponents/webcomponentsjs/issues/833
Closes https://github.com/Polymer/polymer/issues/4844
Closes https://github.com/Polymer/polymer/issues/3205
I suspect this also closes https://github.com/webcomponents/webcomponentsjs/issues/422, please verify this one