### PR TITLE
Fixed host selector issue by transforming selectors also on ShadyDOM.

### DIFF
--- a/src/style-properties.js
+++ b/src/style-properties.js
@@ -327,8 +327,8 @@ class StyleProperties {
     }
     let selectorToMatch = hostScope;
     if (isHost) {
-      // need to transform :host under ShadowDOM because `:host` does not work with `matches`
-      if (nativeShadow && !rule.transformedSelector) {
+      // need to transform :host because `:host` does not work with `matches`
+      if (!rule.transformedSelector) {
         // transform :host into a matchable selector
         rule.transformedSelector =
         StyleTransformer._transformRuleCss(


### PR DESCRIPTION
This will fix #151. I don't why the condition was only targetting native ShadowDOM, as ShadyDOM definitely doesn't have `:host(something` support.


Tests passed for Chrome 63.
Didn't add an additional unit test though. :-/