### PR TITLE
Avoid "TypeError: Invalid calling object" exceptions in IE

### DIFF
--- a/src/style-properties.js
+++ b/src/style-properties.js
@@ -19,11 +19,16 @@ import StyleInfo from './style-info.js';
 
 // TODO: dedupe with shady
 /**
- * @const {function(string):boolean}
+ * @param {string} selector
+ * @return {boolean}
+ * @this {Element}
  */
-const matchesSelector = ((p) => p.matches || p.matchesSelector ||
-  p.mozMatchesSelector || p.msMatchesSelector ||
-p.oMatchesSelector || p.webkitMatchesSelector)(window.Element.prototype);
+const matchesSelector = function(selector) {
+  const method = this.matches || this.matchesSelector ||
+    this.mozMatchesSelector || this.msMatchesSelector ||
+    this.oMatchesSelector || this.webkitMatchesSelector;
+  return method && method.call(this, selector);
+};
 
 const IS_IE = navigator.userAgent.match('Trident');
 


### PR DESCRIPTION
In some instances, Internet Explorer was throwing a "TypeError: Invalid calling object" which was caused by the matchesSelector helper method. Normally this error is caused by aliasing native methods and calling them with the wrong `this` context.

Reworks the matchesSelector helper to avoid this scenario.

Test cases are extremely hard to produce - I only found this issue on a large internal project. This change alleviated the issue.