### PR TITLE
Correctly handle deeply nested scopes

### DIFF
--- a/src/document-watcher.js
+++ b/src/document-watcher.js
@@ -72,13 +72,28 @@ function handler(mxns) {
           continue;
         }
         newScope = getIsExtends(host).is;
-        if (currentScope === newScope) {
-          // make sure all the subtree elements are scoped correctly
-          let unscoped = window['ShadyDOM']['nativeMethods']['querySelectorAll'].call(
-            n, `:not(.${StyleTransformer.SCOPE_NAME})`);
-          for (let j = 0; j < unscoped.length; j++) {
-            StyleTransformer.element(unscoped[j], currentScope);
+        // make sure all the subtree elements are scoped correctly
+        let unscopedNodes = window['ShadyDOM']['nativeMethods']['querySelectorAll'].call(
+          n, `:not(.${StyleTransformer.SCOPE_NAME})`);
+        for (let j = 0; j < unscopedNodes.length; j++) {
+          // it's possible, during large batch inserts, that nodes that aren't
+          // scoped within the current scope were added. 
+          // To make sure that any unscoped nodes that were inserted in the current batch are correctly styled,
+          // query all unscoped nodes and force their style-scope to be applied.
+          // This could happen if a sub-element appended an unscoped node in its shadowroot and this function
+          // runs on a parent element of the host of that unscoped node:
+          // parent-element -> element -> unscoped node
+          // Here unscoped node should have the style-scope element, not parent-element.
+          const unscopedNode = unscopedNodes[j];
+          const rootForUnscopedNode = unscopedNode.getRootNode();
+          const hostForUnscopedNode = rootForUnscopedNode .host;
+          if (!hostForUnscopedNode) {
+            continue;
           }
+          const scopeForPreviouslyUnscopedNode = getIsExtends(hostForUnscopedNode).is;
+          StyleTransformer.element(unscopedNode, scopeForPreviouslyUnscopedNode);
+        }
+        if (newScope === currentScope) {
           continue;
         }
         if (currentScope) {

--- a/tests/dynamic-scoping.html
+++ b/tests/dynamic-scoping.html
@@ -32,7 +32,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 <body>
 
   <style>
-    x-container, x-sample {
+    x-container, x-sample, x-sample-dynamic,  x-container-dynamic {
       display: block;
       padding: 10px;
       margin: 10px;
@@ -122,6 +122,34 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <oob-parent></oob-parent>
   <oob-other-parent></oob-other-parent>
 
+  <template id="x-sample-dynamic">
+    <style>
+      .target {
+        background-color: rgb(255, 0, 0);
+      }
+    </style>
+    <h2></h2>
+    <p>here .target elements are red</p>
+    <div class="target">I'm red</div>
+    <template id="renderer">
+      <div class="target"></div>
+    </template>
+  </template>
+
+  <template id="x-container-dynamic">
+    <style>
+      .target {
+        background-color: rgb(123, 123, 123);
+      }
+    </style>
+    <h1>x-container</h1>
+    <p>here .target elements are gray</p>
+    <div class="target">I'm gray</div>
+    <slot></slot>
+  </template>
+
+  <x-container-dynamic></x-container-dynamic>
+
   <script>
     suite('Dynamic Scoping', () => {
       function stamp(parent, host) {
@@ -176,6 +204,44 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           done();
         });
       })
+      function makeDynamicElement(name, connectedCallback) {
+        let template = document.querySelector(`template#${name}`);
+        if (template && window.ShadyCSS) {
+          window.ShadyCSS.prepareTemplate(template, name);
+        }
+        window.customElements.define(name, class extends window.HTMLElement {
+          constructor() {
+            super();
+            if (template && !this.shadowRoot) {
+              this.attachShadow({mode: 'open'});
+              this.shadowRoot.appendChild(document.importNode(template.content, true));
+            }
+          }
+          connectedCallback() {
+            window.ShadyCSS && window.ShadyCSS.styleElement(this);
+            if (connectedCallback) {
+              connectedCallback.call(this);
+            }
+          }
+        });
+      }
+      test('Nested DOM is scoped correctly when created dynamically inside a dynamic container', (done) => {
+        makeDynamicElement('x-container-dynamic');
+        makeDynamicElement('x-sample-dynamic');
+        const dynamicDiv = document.createElement('div');
+        dynamicDiv.classList.add('target');
+        dynamicDiv.innerText = 'I was created dynamically';
+        const dynamicSample = document.createElement('x-sample-dynamic');
+        const dynamicContainer = document.createElement('x-container-dynamic');
+        dynamicSample.shadowRoot.appendChild(dynamicDiv);
+        dynamicContainer.shadowRoot.appendChild(dynamicSample);
+        document.querySelector('x-container-dynamic').shadowRoot.appendChild(dynamicContainer);
+        requestAnimationFrame(() => {
+          dynamicSample.shadowRoot.querySelectorAll('div.target').forEach((target) => 
+            assert.equal(getComputedStyle(target).backgroundColor,'rgb(255, 0, 0)'));
+          done();
+        });
+      });
     });
   </script>
 </body>


### PR DESCRIPTION
When large batch DOM updates are made the document mutation observer that handles rescoping things will fire with only the root most node of the newly attached tree. This is expected behavior of mutation observer. As a result it's possible that multiple shadow roots will be appended in a single tick of the observer with unscoped children. Previously every unscoped child would be scoped to the scope of the root most scope. However this can be incorrect when multiple shadow boundaries have been appended in a tree. In order to prevent incorrectly scoping children nodes before scoping them their root and host need to be identified. The correct scope will then be applied instead of assuming that it's the scope of the newly added node.

This fixes: Polymer/polymer#4910 in addition to the intent behind #162. 

[This reproducer](https://codepen.io/trescenzi/pen/bvXxMG?editors=1010) shows, as simply as I could, the root problem. It also shows the necessity of checking for unscoped children whenever the mutation observer is called, not just when the scope being updated is the same as before(`newScope === currentScope`). However I'm concerned that this will be a performance hit so I'm not sure that this is the best solution.

If I'm missing a way to correctly use ShadyCSS please let me know. I've tried using `styleElement` and `styleSubtree` but it didn't seem to solve the problem. It looks like the intent of the MutationObserver is to handle situations like these where unscoped, and incorrectly scoped, elements are added dynamically into the DOM so I figured addressing the problem here was best.

Thank you!