### PR TITLE
Make sure to only scope nodes once

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,8 @@ addons:
   firefox: latest
   chrome: stable
 before_script:
-- npm run build
 - npm run lint
-- gulp test-modules
+- npm run build
 script:
 - xvfb-run wct
 - if [ "${TRAVIS_PULL_REQUEST}" = "false" ]; then wct -s 'windows 10/microsoftedge@16' -s 'windows 10/microsoftedge@15' -s 'windows 8.1/internet explorer@11' -s 'macos 10.13/safari@11' -s 'macos 10.12/safari@10' -s 'os x 10.11/safari@9' -s 'Linux/chrome@41'; fi

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
   "scripts": {
     "build": "gulp",
     "lint": "eslint src test entrypoints",
-    "test": "npm run lint && gulp test-modules && wct",
-    "prepack": "npm run build"
+    "test": "npm run lint && gulp && wct",
+    "prepack": "gulp closure"
   },
   "files": [
     "apply-shim.html",

--- a/src/document-watcher.js
+++ b/src/document-watcher.js
@@ -63,7 +63,7 @@ function handler(mxns) {
       let currentScope = getCurrentScope(n);
       // node was scoped, but now is in document
       if (currentScope && root === n.ownerDocument) {
-        StyleTransformer.dom(n, currentScope, true);
+        StyleTransformer.domRemoveScope(n, currentScope);
       } else if (root.nodeType === Node.DOCUMENT_FRAGMENT_NODE) {
         let newScope;
         let host = /** @type {ShadowRoot} */(root).host;

--- a/src/document-watcher.js
+++ b/src/document-watcher.js
@@ -74,10 +74,7 @@ function handler(mxns) {
         newScope = getIsExtends(host).is;
         // rescope current node and subtree if necessary
         if (newScope !== currentScope) {
-          if (currentScope) {
-            StyleTransformer.dom(n, currentScope, true);
-          }
-          StyleTransformer.dom(n, newScope);
+          StyleTransformer.domReplaceScope(n, currentScope, newScope);
         }
         // make sure all the subtree elements are scoped correctly
         let unscopedNodes = window['ShadyDOM']['nativeMethods']['querySelectorAll'].call(

--- a/src/document-watcher.js
+++ b/src/document-watcher.js
@@ -72,12 +72,19 @@ function handler(mxns) {
           continue;
         }
         newScope = getIsExtends(host).is;
+        // rescope current node and subtree if necessary
+        if (newScope !== currentScope) {
+          if (currentScope) {
+            StyleTransformer.dom(n, currentScope, true);
+          }
+          StyleTransformer.dom(n, newScope);
+        }
         // make sure all the subtree elements are scoped correctly
         let unscopedNodes = window['ShadyDOM']['nativeMethods']['querySelectorAll'].call(
           n, `:not(.${StyleTransformer.SCOPE_NAME})`);
         for (let j = 0; j < unscopedNodes.length; j++) {
           // it's possible, during large batch inserts, that nodes that aren't
-          // scoped within the current scope were added. 
+          // scoped within the current scope were added.
           // To make sure that any unscoped nodes that were inserted in the current batch are correctly styled,
           // query all unscoped nodes and force their style-scope to be applied.
           // This could happen if a sub-element appended an unscoped node in its shadowroot and this function
@@ -86,20 +93,13 @@ function handler(mxns) {
           // Here unscoped node should have the style-scope element, not parent-element.
           const unscopedNode = unscopedNodes[j];
           const rootForUnscopedNode = unscopedNode.getRootNode();
-          const hostForUnscopedNode = rootForUnscopedNode .host;
+          const hostForUnscopedNode = rootForUnscopedNode.host;
           if (!hostForUnscopedNode) {
             continue;
           }
           const scopeForPreviouslyUnscopedNode = getIsExtends(hostForUnscopedNode).is;
           StyleTransformer.element(unscopedNode, scopeForPreviouslyUnscopedNode);
         }
-        if (newScope === currentScope) {
-          continue;
-        }
-        if (currentScope) {
-          StyleTransformer.dom(n, currentScope, true);
-        }
-        StyleTransformer.dom(n, newScope);
       }
     }
   }

--- a/src/scoping-shim.js
+++ b/src/scoping-shim.js
@@ -127,7 +127,7 @@ export default class ScopingShim {
   prepareTemplateDom(template, elementName) {
     if (!nativeShadow && !template._domPrepared) {
       template._domPrepared = true;
-      StyleTransformer.dom(template.content, elementName);
+      StyleTransformer.domAddScope(template.content, elementName);
     }
   }
   _generateStaticStyle(info, rules, shadowroot, placeholder) {

--- a/src/style-transformer.js
+++ b/src/style-transformer.js
@@ -79,7 +79,7 @@ class StyleTransformer {
 
   /**
    * @param {!Node} startNode
-   * @param {!function(node)} transformer
+   * @param {!function(!Node)} transformer
    */
   _transformDom(startNode, transformer) {
     if (startNode.nodeType === Node.ELEMENT_NODE) {

--- a/src/style-transformer.js
+++ b/src/style-transformer.js
@@ -46,6 +46,7 @@ class StyleTransformer {
    * @param {!Node} node
    * @param {string} scope
    * @param {boolean=} shouldRemoveScope
+   * @deprecated
    */
   dom(node, scope, shouldRemoveScope) {
     // one time optimization to skip scoping...
@@ -54,6 +55,23 @@ class StyleTransformer {
     } else {
       const fn = (node) => {
         this.element(node, scope || '', shouldRemoveScope);
+      };
+      this._transformDom(node, fn);
+    }
+  }
+
+  /**
+   * Given a node and scope name, add a scoping class to each node in the tree.
+   * @param {!Node} node
+   * @param {string} scope
+   */
+  domAddScope(node, scope) {
+    // one time optimization to skip scoping...
+    if (node['__styleScoped']) {
+      node['__styleScoped'] = null;
+    } else {
+      const fn = (node) => {
+        this.element(node, scope || '');
       };
       this._transformDom(node, fn);
     }
@@ -127,6 +145,22 @@ class StyleTransformer {
       const fn = (node) => {
         this.element(node, oldScope, true);
         this.element(node, newScope);
+      };
+      this._transformDom(node, fn);
+    }
+  }
+  /**
+   * Given a node, remove the scoping class to each subnode in the tree.
+   * @param {!Node} node
+   * @param {string} oldScope
+   */
+  domRemoveScope(node, oldScope) {
+    // one time optimization to skip scoping...
+    if (node['__styleScoped']) {
+      node['__styleScoped'] = null;
+    } else {
+      const fn = (node) => {
+        this.element(node, oldScope, true);
       };
       this._transformDom(node, fn);
     }

--- a/src/style-transformer.js
+++ b/src/style-transformer.js
@@ -160,7 +160,7 @@ class StyleTransformer {
       node['__styleScoped'] = null;
     } else {
       const fn = (node) => {
-        this.element(node, oldScope, true);
+        this.element(node, oldScope || '', true);
       };
       this._transformDom(node, fn);
     }


### PR DESCRIPTION
Reorder the scoping of the added node's subtree to be first, then catch
any other unscoped nodes. This makes sure the subtree of n will not have
double work applied