### PR TITLE
styleSubtree() should also consider slot elements

### DIFF
--- a/entrypoints/apply-shim.js
+++ b/entrypoints/apply-shim.js
@@ -96,6 +96,10 @@ class ApplyShimInterface {
       for (let i = 0; i < shadowChildren.length; i++) {
         this.styleSubtree(/** @type {HTMLElement} */(shadowChildren[i]));
       }
+      let children = element.children;
+      for (let i = 0; i < children.length; i++) {
+        this.styleSubtree(/** @type {HTMLElement} */(children[i]));
+      }
     } else {
       let children = element.children || element.childNodes;
       for (let i = 0; i < children.length; i++) {


### PR DESCRIPTION
Possible fix for #223 

Slot elements are not styled in IE11 as they are never considered in the styleSubtree() method.

With this change (iterating also over the children of the element) it does work.

But I am unsure if this is the correct way to get the <slot> elements.

