### PR TITLE
Enforce classes classes in setElementClass

### DIFF
--- a/src/scoping-shim.js
+++ b/src/scoping-shim.js
@@ -557,8 +557,7 @@ export default class ScopingShim {
     StyleTransformer.element(node, scope);
   }
   /**
-   * @param 
-   {!Element} node
+   * @param {!Element} node
    * @param {string} scope
    */
   unscopeNode(node, scope) {

--- a/src/scoping-shim.js
+++ b/src/scoping-shim.js
@@ -512,7 +512,14 @@ export default class ScopingShim {
   // any necessary ShadyCSS static and property based scoping selectors
   setElementClass(element, classString) {
     let root = StyleUtil.wrap(element).getRootNode();
-    let classes = classString ? classString.split(/\s/) : [];
+    let classes = [];
+    if( classString) {
+      if (Array.isArray(classString) {
+        classes = classString;
+      } else {
+          classes = classString.split(/\s/);
+      }
+    }
     let scopeName = root.host && root.host.localName;
     // If no scope, try to discover scope name from existing class.
     // This can occur if, for example, a template stamped element that

--- a/src/scoping-shim.js
+++ b/src/scoping-shim.js
@@ -512,13 +512,12 @@ export default class ScopingShim {
   // any necessary ShadyCSS static and property based scoping selectors
   setElementClass(element, classString) {
     let root = StyleUtil.wrap(element).getRootNode();
-    let classes = [];
-    if( classString) {
-      if (Array.isArray(classString) {
-        classes = classString;
-      } else {
-          classes = classString.split(/\s/);
-      }
+    let classes;
+    if (classString) {
+      let definitelyString = typeof classString === 'string' ? classString : String(classString);
+      classes = definitelyString.split(/\s/);
+    } else {
+      classes = [];
     }
     let scopeName = root.host && root.host.localName;
     // If no scope, try to discover scope name from existing class.
@@ -558,7 +557,8 @@ export default class ScopingShim {
     StyleTransformer.element(node, scope);
   }
   /**
-   * @param {!Element} node
+   * @param 
+   {!Element} node
    * @param {string} scope
    */
   unscopeNode(node, scope) {


### PR DESCRIPTION
If libraries or users accidentally pass an array of strings into setElemntClass, Polymer will current throw exceptions. Instead, gracefully handle these types of errors.